### PR TITLE
Fix V initialization in PolicyIterationModified

### DIFF
--- a/src/mdptoolbox/mdp.py
+++ b/src/mdptoolbox/mdp.py
@@ -852,7 +852,7 @@ class PolicyIterationModified(PolicyIteration):
             self.thresh = self.epsilon
 
         if self.discount == 1:
-            self.V = _np.zeros((self.S, 1))
+            self.V = _np.zeros(self.S)
         else:
             Rmin = min(R.min() for R in self.R)
             self.V = 1 / (1 - self.discount) * Rmin * _np.ones((self.S,))


### PR DESCRIPTION
`V` was initialized with the wrong dimensions for undiscounted MDPs in `PolicyIterationModified`, which caused an exception to be raised in `_bellmanOperator`.