### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,13 +7,13 @@ Markov Decision Process (MDP) Toolbox for Python
 .. image:: https://coveralls.io/repos/sawcordwell/pymdptoolbox/badge.png
     :target: https://coveralls.io/r/sawcordwell/pymdptoolbox
     :alt: Code Coverage
-.. image:: https://pypip.in/py_versions/pymdptoolbox/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/pymdptoolbox.svg
     :target: https://pypi.python.org/pypi/pymdptoolbox/
     :alt: Supported Python versions
-.. image:: https://pypip.in/implementation/pymdptoolbox/badge.svg
+.. image:: https://img.shields.io/pypi/implementation/pymdptoolbox.svg
     :target: https://pypi.python.org/pypi/pymdptoolbox/
     :alt: Supported Python implementations
-.. image:: https://pypip.in/license/pymdptoolbox/badge.svg
+.. image:: https://img.shields.io/pypi/l/pymdptoolbox.svg
     :target: https://pypi.python.org/pypi/pymdptoolbox/
     :alt: License
 
@@ -65,22 +65,22 @@ Index or from GitHub. Both of these are explained below.
 
 Python Package Index (PyPI)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. image:: https://pypip.in/download/pymdptoolbox/badge.svg
+.. image:: https://img.shields.io/pypi/dm/pymdptoolbox.svg
     :target: https://pypi.python.org/pypi//pymdptoolbox/
     :alt: Downloads
-.. image:: https://pypip.in/version/pymdptoolbox/badge.svg
+.. image:: https://img.shields.io/pypi/v/pymdptoolbox.svg
     :target: https://pypi.python.org/pypi/pymdptoolbox/
     :alt: Latest Version
-.. image:: https://pypip.in/status/pymdptoolbox/badge.svg
+.. image:: https://img.shields.io/pypi/status/pymdptoolbox.svg
     :target: https://pypi.python.org/pypi/pymdptoolbox/
     :alt: Development Status
-.. image:: https://pypip.in/wheel/pymdptoolbox/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/pymdptoolbox.svg
     :target: https://pypi.python.org/pypi/pymdptoolbox/
     :alt: Wheel Status
 .. image:: https://pypip.in/egg/pymdptoolbox/badge.svg
     :target: https://pypi.python.org/pypi/pymdptoolbox/
     :alt: Egg Status
-.. image:: https://pypip.in/format/pymdptoolbox/badge.svg
+.. image:: https://img.shields.io/pypi/format/pymdptoolbox.svg
     :target: https://pypi.python.org/pypi/pymdptoolbox/
     :alt: Download format
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pymdptoolbox))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pymdptoolbox`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.