### PR TITLE
Fix broken examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,7 +147,7 @@ optimal policy.
 
 .. code:: python
 
-  import mdptoolbox.example
+  import mdptoolbox
   P, R = mdptoolbox.example.forest()
   vi = mdptoolbox.mdp.ValueIteration(P, R, 0.9)
   vi.run()

--- a/src/mdptoolbox/mdp.py
+++ b/src/mdptoolbox/mdp.py
@@ -985,7 +985,7 @@ class QLearning(MDP):
         this vector for the default value of N is 100 (N/100).
 
     Examples
-    ---------
+    --------
     >>> # These examples are reproducible only if random seed is set to 0 in
     >>> # both the random and numpy.random modules.
     >>> import numpy as np


### PR DESCRIPTION
Fixes broken one broken example (won't compile in its original state) from the Quick Usage section, and another one from the `QLearning` docstring.