### PR TITLE
Fix division by zero in `ValueIteration._boundIter`

### DIFF
--- a/src/mdptoolbox/mdp.py
+++ b/src/mdptoolbox/mdp.py
@@ -1412,9 +1412,12 @@ class ValueIteration(MDP):
         null, value = self._bellmanOperator()
         # p 201, Proposition 6.6.5
         span = _util.getSpan(value - Vprev)
-        max_iter = (_math.log((epsilon * (1 - self.discount) / self.discount) /
-                    span) / _math.log(self.discount * k))
-        # self.V = Vprev
+        if span == 0:  # avoid divide-by-zero error
+            max_iter = 0
+        else:
+            max_iter = (_math.log((epsilon * (1 - self.discount) / self.discount) /
+                        span) / _math.log(self.discount * k))
+            # self.V = Vprev
 
         self.max_iter = int(_math.ceil(max_iter))
 

--- a/src/tests/test_ValueIteration.py
+++ b/src/tests/test_ValueIteration.py
@@ -58,3 +58,9 @@ def test_ValueIteration_rand_sparse():
     sdp = mdptoolbox.mdp.ValueIteration(P_rand_sparse, R_rand_sparse, 0.9)
     sdp.run()
     assert sdp.policy
+
+def test_ValueIteration_all_zero():
+    sdp = mdptoolbox.mdp.ValueIteration(P_rand, np.zeros_like(R_rand), 0.9)
+    sdp.run()
+    assert sdp.policy
+    assert (np.array(sdp.V) == 0.0).all()


### PR DESCRIPTION
`mdp.ValueIteration` uses `ValueIteration._boundIter` to set `self.max_iter` for discounted MDPs. This is based on the span: the difference between the minimum and maximum values after one step of the Bellman operator.

The problem is for some MDPs the value can be *identical* for all states after a single application of the Bellman operator. This happens when $R(s,a)$ is equal to $Q(s,a)$ -- not common, but it does happen (e.g. any MDP with an all-zero reward is a degenerate example). In this case, `span` is `0` and `max_iter` becomes negative infinity.

If my understanding of the bound is correct, in this case we actually don't need to perform any iterations of value iteration -- the all-zero initialisation is OK. So I've added an explicit check that sets `max_iter = 0` in this case avoiding the division by zero. I've also added a regression test for the all-zero MDP.

Some doctests are failing but they were failing before. All other tests are passing on my machine.