### PR TITLE
Fix typo in doc

### DIFF
--- a/src/mdptoolbox/mdp.py
+++ b/src/mdptoolbox/mdp.py
@@ -838,7 +838,7 @@ class PolicyIteration(MDP):
 
 class PolicyIterationModified(PolicyIteration):
 
-    """A discounted MDP  solved using a modifified policy iteration algorithm.
+    """A discounted MDP  solved using a modified policy iteration algorithm.
 
     Arguments
     ---------


### PR DESCRIPTION
Replace `modifified` by `modified` in `src/mdptoolbox/mdp.py`