### PR TITLE
Not working when initial_value is numpy.

### DIFF
--- a/src/mdptoolbox/mdp.py
+++ b/src/mdptoolbox/mdp.py
@@ -1347,19 +1347,19 @@ class ValueIteration(MDP):
 
     """
 
-    def __init__(self, transitions, reward, discount, epsilon=0.01,
-                 max_iter=1000, initial_value=0, skip_check=False):
-        # Initialise a value iteration MDP.
+    def __init__(self, transitions, reward, discount, epsilon=0.01,         
+                 max_iter=1000, initial_value=_np.zeros(1), skip_check=False):     #initial_value=0 -> initial_value=_np.zeros(1) To prevent Error when comparing numpy and integer. 
+        # Initialise a value iteration MDP.         
 
         MDP.__init__(self, transitions, reward, discount, epsilon, max_iter,
                      skip_check=skip_check)
-
+    
         # initialization of optional arguments
-        if initial_value == 0:
+        if len(initial_value) != self.S:            #When initial_value is given as array(numpy), integer and numpy can't be compared. 
+            assert initial_value == _np.zeros(1), "The initial value must be " \
+                "a vector of length S."
             self.V = _np.zeros(self.S)
         else:
-            assert len(initial_value) == self.S, "The initial value must be " \
-                "a vector of length S."
             self.V = _np.array(initial_value).reshape(self.S)
         if self.discount < 1:
             # compute a bound for the number of iterations and update the


### PR DESCRIPTION
In ValueIteration, Numpy and Integer can't be compared when initial_value is given as numpy.

# vi = mdptoolbox.mdp.ValueIteration(P,R,discount, initial_value=initial_values)

If initial_values is integer and greater than zero. len(integer) won't work.
Or initial_values is Numpy and it's Lengths are exactly same as S (states). initial_value == 0 won't work.
and will make Error.
"""
import mdptoolbox.example
import mdptoolbox.mdp
import numpy as np

P,R = mdptoolbox.example.forest()

initial_values = np.array([       # Forest have three state.
    0,0,0
])

discount = 0.96

vi = mdptoolbox.mdp.ValueIteration(P,R,discount, initial_value=initial_values)

vi.run()

print(vi.V)

#expected : (5.93215488, 9.38815488, 13.38815488)

#result : ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
"""
